### PR TITLE
Fix/longer org name bug

### DIFF
--- a/src/editors/sharedComponents/TypeaheadDropdown/FormGroup.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/FormGroup.jsx
@@ -24,7 +24,7 @@ const FormGroup = (props) => {
       <Form.Control
         data-testid="formControl"
         aria-invalid={props.errorMessage}
-        autoComplete={props.autoComplete ? 'on' : 'off'}
+        autoComplete={props.autoComplete || 'off'}
         onChange={props.handleChange}
         onFocus={handleFocus}
         onClick={handleClick}
@@ -58,7 +58,7 @@ const FormGroup = (props) => {
 FormGroup.defaultProps = {
   as: 'input',
   errorMessage: '',
-  autoComplete: null,
+  autoComplete: 'off',
   readOnly: false,
   handleBlur: null,
   handleChange: () => {},

--- a/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
@@ -48,24 +48,25 @@ class TypeaheadDropdown extends React.Component {
 
     const sortedOptions = sortBy(options, (option) => option.toLowerCase());
 
-    return sortedOptions.map((opt) => {
-      let value = opt;
-      if (value.length > 30) {
-        value = value.substring(0, 30).concat('...');
-      }
-
-      return (
-        <button
-          type="button"
-          className="dropdown-item data-hj-suppress"
-          value={value}
-          key={value}
-          onClick={(e) => { this.handleItemClick(e); }}
-        >
-          {value}
-        </button>
-      );
-    });
+    return sortedOptions.map((opt) => (
+      <button
+        type="button"
+        className="dropdown-item data-hj-suppress"
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          display: 'block',
+          width: '100%',
+        }}
+        value={opt}
+        key={opt}
+        title={opt}
+        onClick={(e) => { this.handleItemClick(e); }}
+      >
+        {opt}
+      </button>
+    ));
   }
 
   setValue(value) {

--- a/src/editors/sharedComponents/TypeaheadDropdown/index.test.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.test.jsx
@@ -68,6 +68,20 @@ describe('common/OrganizationDropdown.jsx', () => {
     fireEvent.click(optionsList.at([0]));
     expect(formInput.value).toEqual(newProps.options[0]);
   });
+  it('selects long organization name correctly', () => {
+    const longOrgName = 'PalpungThuptenLungtokKunphenCholing';
+    const newProps = { ...defaultProps, options: ['ShortOrg', longOrgName] };
+    renderComponent(newProps);
+    const formInput = screen.getByTestId('formControl');
+    fireEvent.click(formInput);
+    const optionsList = within(screen.getByTestId('dropdown-container')).getAllByRole('button');
+    // Find the button with the long org name
+    const longOrgButton = optionsList.find(btn => btn.value === longOrgName);
+    expect(longOrgButton).toBeTruthy();
+    expect(longOrgButton.title).toEqual(longOrgName);
+    fireEvent.click(longOrgButton);
+    expect(formInput.value).toEqual(longOrgName);
+  });
   it('toggles options list', async () => {
     const newProps = { ...defaultProps, options: ['opt1', 'opt2'] };
     renderComponent(newProps);


### PR DESCRIPTION
**Issue:** 
Long organization names were truncated to 30 characters for display. The truncated value was stored in the dropdown button, so clicking a long name couldn't find the real value.

**Fix:**
 Keep the full name as the button's value/key, and add a tooltip (title) with the full text.