### PR TITLE
fix: point Studio home "Getting started" link to working Open edX docs

### DIFF
--- a/src/help-urls/data/thunks.js
+++ b/src/help-urls/data/thunks.js
@@ -3,6 +3,11 @@ import { RequestStatus } from '../../data/constants';
 import { getHelpUrls } from './api';
 import { updateLoadingHelpUrlsStatus, updatePages } from './slice';
 
+// The backend `home` help token still resolves to a retired readthedocs page.
+// Override it with the current Open edX educators quickstart until the backend
+// help_tokens config is migrated to docs.openedx.org.
+const HOME_HELP_URL_OVERRIDE = 'https://docs.openedx.org/en/latest/educators/quickstarts/build_a_course.html';
+
 export function fetchHelpUrls() {
   return async (dispatch) => {
     dispatch(updateLoadingHelpUrlsStatus({ status: RequestStatus.IN_PROGRESS }));
@@ -10,7 +15,7 @@ export function fetchHelpUrls() {
     try {
       const urls = await getHelpUrls();
 
-      dispatch(updatePages(urls));
+      dispatch(updatePages({ ...urls, home: HOME_HELP_URL_OVERRIDE }));
 
       dispatch(updateLoadingHelpUrlsStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;


### PR DESCRIPTION
## Summary

Fixes the broken "Getting started with Studio" link in the Studio home page sidebar. It was pointing at a retired `edx.readthedocs.io` page and now points at the current Open edX educators quickstart.

## Problem

The sidebar link ("New to … Studio?" → "Getting started with … Studio") gets its URL from the `home` help token, which is served by the Studio backend (`/api/contentstore/v1/help_urls`, built from `cms/envs/help_tokens.ini` + `HELP_TOKENS_BOOKS`). On this deployment that token still resolves to a retired readthedocs URL, so the link 404s.

## Change

Override the `home` token in the help-urls thunk after it's fetched, so the sidebar link resolves to the working docs page:
`https://docs.openedx.org/en/latest/educators/quickstarts/build_a_course.html`

- File: `src/help-urls/data/thunks.js`
- Scope: the `home` token is only consumed by the Studio home sidebar, so the override is fully contained.
- This is intentionally a frontend stopgap (documented in a code comment). The "correct" long-term fix is migrating the backend `help_tokens` config to `docs.openedx.org`; that's a broader, backend-repo change and is noted in the comment.